### PR TITLE
Remove unnecessary migrations

### DIFF
--- a/db/migrate/20200609005643_rename_type_to_design_type.rb
+++ b/db/migrate/20200609005643_rename_type_to_design_type.rb
@@ -1,5 +1,0 @@
-class RenameTypeToDesignType < ActiveRecord::Migration[6.0]
-  def change
-    rename_column :designs, :type, :design_type
-  end
-end

--- a/db/migrate/20210102184309_drop_table_colors.rb
+++ b/db/migrate/20210102184309_drop_table_colors.rb
@@ -1,5 +1,0 @@
-class DropTableColors < ActiveRecord::Migration[6.0]
-  def change
-    drop_table :colors
-  end
-end

--- a/db/migrate/20210102225246_drop_table_designs.rb
+++ b/db/migrate/20210102225246_drop_table_designs.rb
@@ -1,5 +1,0 @@
-class DropTableDesigns < ActiveRecord::Migration[6.0]
-  def change
-    drop_table :designs
-  end
-end


### PR DESCRIPTION
### Motivation
Remove unnecessary migrations.
### Activities
- Removed the migration that rename the designs type column to design_type
- Removed the migration that drops the colors table
- Removed the migration that drops the designs table